### PR TITLE
Create native version of later_fd()

### DIFF
--- a/R/later.R
+++ b/R/later.R
@@ -294,9 +294,9 @@ create_canceller <- function(id, loop_id) {
 #' @param func A function that takes a single argument, a logical vector that
 #'   indicates which file descriptors are ready (a concatenation of `readfds`,
 #'   `writefds` and `exceptfds`). This may be all `FALSE` if the
-#'   `timeout` argument is non-`Inf`. Invalid file descriptors (such as those
-#'   already closed) are returned as `NA`, as are `readfds` and `writefds` with
-#'   error conditions pending.
+#'   `timeout` argument is non-`Inf`. File descriptors with error conditions
+#'   pending are represented as `NA`, as are invalid file descriptors such as
+#'   those already closed.
 #' @param readfds Integer vector of file descriptors, or Windows SOCKETs, to
 #'   monitor for being ready to read.
 #' @param writefds Integer vector of file descriptors, or Windows SOCKETs, to

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The first argument is a pointer to a function that takes one `void*` argument an
 ```cpp
 void later_fd(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double secs)
 ```
-The first argument is a pointer to a function that takes two arguments. The first of those is an `int*` which is provided by `later_fd()` when called back containing the values `0`, `1` or `NA_INTEGER` for the readiness of each file descriptor (or an error condition). The second argumentis a `void*` that will be passed as the second argument of the function when it's called back. The third is the total number of file descriptors being passed, the fourth a pointer to a vector of `stuct pollfds`, and the fifth being the number of seconds until timing out.
+The first argument is a pointer to a function that takes two arguments. The first of those is an `int*` which is provided by `later_fd()` when called back containing the values `0`, `1` or `NA_INTEGER` for the readiness of each file descriptor (or an error condition). The second argumentis a `void*` that will be passed as the second argument of the function when it's called back. The third is the total number of file descriptors being passed, the fourth a pointer to an array of `stuct pollfds`, and the fifth being the number of seconds until timing out.
 
 To use the C++ interface, you'll need to add `later` to your `DESCRIPTION` file under both `LinkingTo` and `Imports`, and also make sure that your `NAMESPACE` file has an `import(later)` entry.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The first argument is a pointer to a function that takes one `void*` argument an
 ```cpp
 void later_fd(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double secs)
 ```
-The first argument is a pointer to a function that takes two arguments. The first of those is an `int*` which is provided by `later_fd()` when called back containing the values `0`, `1` or `NA_INTEGER` for the readiness of each file descriptor (or an error condition). The second argumentis a `void*` that will be passed as the second argument of the function when it's called back. The third is the total number of file descriptors being passed, the fourth a pointer to an array of `stuct pollfds`, and the fifth being the number of seconds until timing out.
+The first argument is a pointer to a function that takes two arguments: the first being an `int*` array provided by `later_fd()` when called back, and the second being a `void*`. The `int*` array will be the length of `num_fds` and contain the values `0`, `1` or `NA_INTEGER` to indicate the readiness of each file descriptor, or an error condition respectively. The second argument `data` is passed to the `void*` argument of the function when it's called back. The third is the total number of file descriptors being passed, the fourth a pointer to an array of `stuct pollfds`, and the fifth the number of seconds to wait until timing out.
 
 To use the C++ interface, you'll need to add `later` to your `DESCRIPTION` file under both `LinkingTo` and `Imports`, and also make sure that your `NAMESPACE` file has an `import(later)` entry.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ void later(void (*func)(void*), void* data, double secs)
 
 The first argument is a pointer to a function that takes one `void*` argument and returns void. The second argument is a `void*` that will be passed to the function when it's called back. And the third argument is the number of seconds to wait (at a minimum) before invoking.
 
+`later::later_fd` is also accessible from `later_api.h` and its prototype looks like this:
+
+```cpp
+void later_fd(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double secs)
+```
+The first argument is a pointer to a function that takes two arguments. The first of those is an `int*` which is provided by `later_fd()` when called back containing the values `0`, `1` or `NA_INTEGER` for the readiness of each file descriptor (or an error condition). The second argumentis a `void*` that will be passed as the second argument of the function when it's called back. The third is the total number of file descriptors being passed, the fourth a pointer to a vector of `stuct pollfds`, and the fifth being the number of seconds until timing out.
+
 To use the C++ interface, you'll need to add `later` to your `DESCRIPTION` file under both `LinkingTo` and `Imports`, and also make sure that your `NAMESPACE` file has an `import(later)` entry.
 
 ### Background tasks

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -99,7 +99,7 @@ inline void later(void (*func)(void*), void* data, double secs) {
 inline void later_fd(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double secs, int loop_id) {
   // See above note for later()
 
-  // The function type for the real execLaterFDNative
+  // The function type for the real execLaterFdNative
   typedef void (*elfdnfun)(void (*)(int *, void *), void *, int, struct pollfd *, double, int);
   static elfdnfun elfdn = NULL;
   if (!elfdn) {
@@ -108,11 +108,11 @@ inline void later_fd(void (*func)(int *, void *), void *data, int num_fds, struc
       // We're not initialized but someone's trying to actually schedule
       // some code to be executed!
       REprintf(
-        "Warning: later::execLaterFDNative called in uninitialized state. "
+        "Warning: later::execLaterFdNative called in uninitialized state. "
         "If you're using <later.h>, please switch to <later_api.h>.\n"
       );
     }
-    elfdn = (elfdnfun) R_GetCCallable("later", "execLaterFDNative");
+    elfdn = (elfdnfun) R_GetCCallable("later", "execLaterFdNative");
   }
 
   // We didn't want to execute anything, just initialize

--- a/inst/include/later.h
+++ b/inst/include/later.h
@@ -13,6 +13,10 @@
 #endif
 
 #ifdef _WIN32
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600 // so R <= 4.1 can find WSAPoll() on Windows
+#endif
+#include <winsock2.h>
 #define WIN32_LEAN_AND_MEAN
 // Taken from http://tolstoy.newcastle.edu.au/R/e2/devel/06/11/1242.html
 // Undefine the Realloc macro, which is defined by both R and by Windows stuff
@@ -20,13 +24,9 @@
 // Also need to undefine the Free macro
 #undef Free
 #include <windows.h>
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600 // so R <= 4.1 can find WSAPoll() on Windows
-#endif
-#include <winsock2.h>
 #else // _WIN32
-#include <pthread.h>
 #include <poll.h>
+#include <pthread.h>
 #endif // _WIN32
 
 #include <Rinternals.h>

--- a/inst/include/later_api.h
+++ b/inst/include/later_api.h
@@ -11,9 +11,10 @@ namespace {
       // See comment in execLaterNative to learn why we need to do this
       // in a statically initialized object
       later::later(NULL, NULL, 0);
+      later::later_fd(NULL, NULL, 0, NULL, 0);
     }
   };
-  
+
   static LaterInitializer init;
 
 } // namespace

--- a/man/later_fd.Rd
+++ b/man/later_fd.Rd
@@ -17,9 +17,9 @@ later_fd(
 \item{func}{A function that takes a single argument, a logical vector that
 indicates which file descriptors are ready (a concatenation of \code{readfds},
 \code{writefds} and \code{exceptfds}). This may be all \code{FALSE} if the
-\code{timeout} argument is non-\code{Inf}. Invalid file descriptors (such as those
-already closed) are returned as \code{NA}, as are \code{readfds} and \code{writefds} with
-error conditions pending.}
+\code{timeout} argument is non-\code{Inf}. File descriptors with error conditions
+pending are represented as \code{NA}, as are invalid file descriptors such as
+those already closed.}
 
 \item{readfds}{Integer vector of file descriptors, or Windows SOCKETs, to
 monitor for being ready to read.}

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -130,8 +130,9 @@ Rcpp::RObject execLater_fd_threaded(std::shared_ptr<ThreadArgs> args) {
   tct_thrd_detach(thr);
 
   Rcpp::XPtr<std::shared_ptr<std::atomic<bool>>> xptr(new std::shared_ptr<std::atomic<bool>>(args->flag), true);
+  SEXP ret = xptr;
 
-  return Rcpp::RObject(xptr);
+  return ret;
 
 }
 

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -104,14 +104,8 @@ static int wait_thread(void *arg) {
     for (int i = 0; i < args->num_fds; i++) {
       (*args->results)[i] = (*args->fds)[i].revents == 0 ? 0 : (*args->fds)[i].revents & (POLLIN | POLLOUT) ? 1: R_NaInt;
     }
-  } else if (ready == 0) {
-    for (int i = 0; i < args->num_fds; i++) {
-      (*args->results)[i] = 0;
-    }
-  } else {
-    for (int i = 0; i < args->num_fds; i++) {
-      (*args->results)[i] = R_NaInt;
-    }
+  } else if (ready < 0) {
+    std::fill(args->results->begin(), args->results->end(), R_NaInt);
   }
 
   callbackRegistryTable.scheduleCallback(later_callback, static_cast<void *>(argsptr.release()), 0, args->loop);

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -116,15 +116,13 @@ static int wait_thread(void *arg) {
 
 }
 
-int execLater_launch_thread(std::shared_ptr<ThreadArgs> args) {
+bool execLater_launch_thread(std::shared_ptr<ThreadArgs> args) {
 
   std::unique_ptr<std::shared_ptr<ThreadArgs>> argsptr(new std::shared_ptr<ThreadArgs>(args));
 
   tct_thrd_t thr;
-  if (tct_thrd_create(&thr, &wait_thread, static_cast<void *>(argsptr.release())) != tct_thrd_success)
-    return 1;
 
-  return 0;
+  return tct_thrd_create(&thr, &wait_thread, static_cast<void *>(argsptr.release())) != tct_thrd_success;
 
 }
 

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -82,6 +82,8 @@ static int wait_thread(void *arg) {
   std::unique_ptr<std::shared_ptr<ThreadArgs>> argsptr(static_cast<std::shared_ptr<ThreadArgs>*>(arg));
   std::shared_ptr<ThreadArgs> args = *argsptr;
 
+  tct_thrd_detach(tct_thrd_current());
+
   // poll() whilst checking for cancellation at intervals
 
   int ready = -1; // initialized at -1 to ensure it runs at least once
@@ -121,7 +123,6 @@ void execLater_launch_thread(std::shared_ptr<ThreadArgs> args) {
   tct_thrd_t thr;
   if (tct_thrd_create(&thr, &wait_thread, static_cast<void *>(argsptr.release())) != tct_thrd_success)
     Rcpp::stop("Thread creation failed");
-  tct_thrd_detach(thr);
 
 }
 

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -116,7 +116,7 @@ static int wait_thread(void *arg) {
 
 }
 
-bool execLater_launch_thread(std::shared_ptr<ThreadArgs> args) {
+static bool execLater_launch_thread(std::shared_ptr<ThreadArgs> args) {
 
   std::unique_ptr<std::shared_ptr<ThreadArgs>> argsptr(new std::shared_ptr<ThreadArgs>(args));
 
@@ -126,7 +126,7 @@ bool execLater_launch_thread(std::shared_ptr<ThreadArgs> args) {
 
 }
 
-SEXP execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
+static SEXP execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
 
   std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(num_fds, fds, timeout, loop_id);
   args->callback = std::unique_ptr<Rcpp::Function>(new Rcpp::Function(callback));
@@ -140,7 +140,7 @@ SEXP execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pollfd *fds,
 }
 
 // native version
-void execLater_fd_impl(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
+static void execLater_fd_impl(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
 
   std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(num_fds, fds, timeout, loop_id);
   args->func = std::bind(func, std::placeholders::_1, data);

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include "tinycthread.h"
 #include "later.h"
+#include "callback_registry_table.h"
 
 #define LATER_POLL_INTERVAL 1024
 #ifdef _WIN32
@@ -21,15 +22,44 @@
 #define LATER_POLL_FUNC poll
 #endif
 
-typedef struct ThreadArgs_s {
+extern CallbackRegistryTable callbackRegistryTable;
+
+class ThreadArgs {
+public:
+  ThreadArgs(
+    int num_fds = 0,
+    double timeout = 0,
+    int loop = 0
+  )
+    : flag(std::make_shared<std::atomic<bool>>(false)),
+      fds(std::unique_ptr<std::vector<struct pollfd>>(new std::vector<struct pollfd>(num_fds))),
+      results(std::unique_ptr<std::vector<int>>(new std::vector<int>(num_fds))),
+      callback(nullptr),
+      func(nullptr),
+      timeout(createTimestamp(timeout)),
+      num_fds(num_fds),
+      loop(loop) {}
+
   std::shared_ptr<std::atomic<bool>> flag;
-  std::unique_ptr<Rcpp::Function> callback;
-  std::unique_ptr<std::vector<int>> fds;
+  std::unique_ptr<std::vector<struct pollfd>> fds;
   std::unique_ptr<std::vector<int>> results;
+  std::unique_ptr<Rcpp::Function> callback;
+  std::function<void (int *)> func;
   Timestamp timeout;
-  int rfds, wfds, efds, num_fds;
+  int num_fds;
   int loop;
-} ThreadArgs;
+
+private:
+  static Timestamp createTimestamp(double timeout) {
+    if (timeout == R_PosInf) {
+      timeout = 3e10; // "1000 years ought to be enough for anybody" --Bill Gates
+    } else if (timeout < 0) {
+      timeout = 1; // curl_multi_timeout() uses -1 to denote a default we set at 1s
+    }
+    return Timestamp(timeout);
+  }
+
+};
 
 static void later_callback(void *arg) {
 
@@ -37,7 +67,11 @@ static void later_callback(void *arg) {
   std::shared_ptr<ThreadArgs> args = *argsptr;
   const bool flag = args->flag->load();
   args->flag->store(true);
-  if (!flag) {
+  if (flag)
+    return;
+  if (args->func != NULL) {
+    args->func(args->results->data());
+  } else {
     Rcpp::LogicalVector results = Rcpp::wrap(*args->results);
     (*args->callback)(results);
   }
@@ -51,31 +85,8 @@ static int wait_thread(void *arg) {
   std::unique_ptr<std::shared_ptr<ThreadArgs>> argsptr(static_cast<std::shared_ptr<ThreadArgs>*>(arg));
   std::shared_ptr<ThreadArgs> args = *argsptr;
 
-  // setup pollfd structs from args->fds
-  std::vector<struct pollfd> pollfds;
-  pollfds.reserve(args->num_fds);
-  struct pollfd pfd;
-
-  for (int i = 0; i < args->rfds; i++) {
-    pfd.fd = (*args->fds)[i];
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-    pollfds.push_back(pfd);
-  }
-  for (int i = args->rfds; i < (args->rfds + args->wfds); i++) {
-    pfd.fd = (*args->fds)[i];
-    pfd.events = POLLOUT;
-    pfd.revents = 0;
-    pollfds.push_back(pfd);
-  }
-  for (int i = args->rfds + args->wfds; i < args->num_fds; i++) {
-    pfd.fd = (*args->fds)[i];
-    pfd.events = 0;
-    pfd.revents = 0;
-    pollfds.push_back(pfd);
-  }
-
   // poll() whilst checking for cancellation at intervals
+
   int ready = -1; // initialized at -1 to ensure it runs at least once
   while (true) {
     double waitFor_ms = args->timeout.diff_secs(Timestamp()) * 1000;
@@ -85,21 +96,16 @@ static int wait_thread(void *arg) {
     } else if (waitFor_ms > LATER_POLL_INTERVAL) {
       waitFor_ms = LATER_POLL_INTERVAL;
     }
-    ready = LATER_POLL_FUNC(pollfds.data(), args->num_fds, static_cast<int>(waitFor_ms));
+    ready = LATER_POLL_FUNC(args->fds->data(), args->num_fds, static_cast<int>(waitFor_ms));
     if (args->flag->load()) return 1;
     if (ready) break;
   }
 
   // store pollfd revents in args->results for use by callback
+
   if (ready > 0) {
-    for (int i = 0; i < args->rfds; i++) {
-      (*args->results)[i] = pollfds[i].revents == 0 ? 0 : pollfds[i].revents & POLLIN ? 1: R_NaInt;
-    }
-    for (int i = args->rfds; i < (args->rfds + args->wfds); i++) {
-      (*args->results)[i] = pollfds[i].revents == 0 ? 0 : pollfds[i].revents & POLLOUT ? 1 : R_NaInt;
-    }
-    for (int i = args->rfds + args->wfds; i < args->num_fds; i++) {
-      (*args->results)[i] = pollfds[i].revents != 0;
+    for (int i = 0; i < args->num_fds; i++) {
+      (*args->results)[i] = (*args->fds)[i].revents == 0 ? 0 : (*args->fds)[i].revents & (POLLIN | POLLOUT) ? 1: R_NaInt;
     }
   } else if (ready == 0) {
     for (int i = 0; i < args->num_fds; i++) {
@@ -111,9 +117,52 @@ static int wait_thread(void *arg) {
     }
   }
 
-  execLaterNative2(later_callback, static_cast<void *>(argsptr.release()), 0, args->loop);
+  callbackRegistryTable.scheduleCallback(later_callback, static_cast<void *>(argsptr.release()), 0, args->loop);
 
   return 0;
+
+}
+
+Rcpp::RObject execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
+
+  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(num_fds, timeout, loop_id);
+  args->callback = std::unique_ptr<Rcpp::Function>(new Rcpp::Function(callback));
+  for (int i = 0; i < num_fds; i++) {
+    (*args->fds)[i] = fds[i];
+  }
+
+  std::unique_ptr<std::shared_ptr<ThreadArgs>> argsptr(new std::shared_ptr<ThreadArgs>(args));
+
+  tct_thrd_t thr;
+  if (tct_thrd_create(&thr, &wait_thread, static_cast<void *>(argsptr.release())) != tct_thrd_success)
+    Rcpp::stop("Thread creation failed");
+  tct_thrd_detach(thr);
+
+  Rcpp::XPtr<std::shared_ptr<std::atomic<bool>>> xptr(new std::shared_ptr<std::atomic<bool>>(args->flag), true);
+
+  return Rcpp::RObject(xptr);
+
+}
+
+// native version
+Rcpp::RObject execLater_fd_impl(void (*func)(int *, void *), void *arg, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
+
+  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(num_fds, timeout, loop_id);
+  args->func = std::bind(func, std::placeholders::_1, arg);
+  for (int i = 0; i < num_fds; i++) {
+    (*args->fds)[i] = fds[i];
+  }
+
+  std::unique_ptr<std::shared_ptr<ThreadArgs>> argsptr(new std::shared_ptr<ThreadArgs>(args));
+
+  tct_thrd_t thr;
+  if (tct_thrd_create(&thr, &wait_thread, static_cast<void *>(argsptr.release())) != tct_thrd_success)
+    Rcpp::stop("Thread creation failed");
+  tct_thrd_detach(thr);
+
+  Rcpp::XPtr<std::shared_ptr<std::atomic<bool>>> xptr(new std::shared_ptr<std::atomic<bool>>(args->flag), true);
+
+  return Rcpp::RObject(xptr);
 
 }
 
@@ -128,49 +177,33 @@ Rcpp::RObject execLater_fd(Rcpp::Function callback, Rcpp::IntegerVector readfds,
   if (num_fds == 0)
     Rcpp::stop("No file descriptors supplied");
 
-  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>();
+  double timeout = timeoutSecs[0];
+  const int loop = loop_id[0];
 
-  double timeout;
-  if (timeoutSecs[0] == R_PosInf) {
-    timeout = 3e10; // "1000 years ought to be enough for anybody" --Bill Gates
-  } else if (timeoutSecs[0] < 0) {
-    timeout = 1; // curl_multi_timeout() uses -1 to denote a default we set at 1s
-  } else {
-    timeout = timeoutSecs[0];
-  }
+  std::vector<struct pollfd> pollfds;
+  pollfds.reserve(num_fds);
+  struct pollfd pfd;
 
-  args->timeout = Timestamp(timeout);
-  args->callback = std::unique_ptr<Rcpp::Function>(new Rcpp::Function(callback));
-  args->flag = std::make_shared<std::atomic<bool>>();
-  args->timeout = timeoutSecs[0];
-  args->loop = loop_id[0];
-  args->rfds = rfds;
-  args->wfds = wfds;
-  args->efds = efds;
-  args->num_fds = num_fds;
-  args->fds = std::unique_ptr<std::vector<int>>(new std::vector<int>());
-  args->fds->reserve(num_fds);
   for (int i = 0; i < rfds; i++) {
-    args->fds->push_back(readfds[i]);
+    pfd.fd = readfds[i];
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    pollfds.push_back(pfd);
   }
   for (int i = 0; i < wfds; i++) {
-    args->fds->push_back(writefds[i]);
+    pfd.fd = writefds[i];
+    pfd.events = POLLOUT;
+    pfd.revents = 0;
+    pollfds.push_back(pfd);
   }
   for (int i = 0; i < efds; i++) {
-    args->fds->push_back(exceptfds[i]);
+    pfd.fd = exceptfds[i];
+    pfd.events = 0;
+    pfd.revents = 0;
+    pollfds.push_back(pfd);
   }
-  args->results = std::unique_ptr<std::vector<int>>(new std::vector<int>(num_fds));
 
-  std::unique_ptr<std::shared_ptr<ThreadArgs>> argsptr(new std::shared_ptr<ThreadArgs>(args));
-
-  tct_thrd_t thr;
-  if (tct_thrd_create(&thr, &wait_thread, static_cast<void *>(argsptr.release())) != tct_thrd_success)
-    Rcpp::stop("Thread creation failed");
-  tct_thrd_detach(thr);
-
-  Rcpp::XPtr<std::shared_ptr<std::atomic<bool>>> xptr(new std::shared_ptr<std::atomic<bool>>(args->flag), true);
-
-  return Rcpp::RObject(xptr);
+  return execLater_fd_impl(callback, num_fds, pollfds.data(), timeout, loop);
 
 }
 
@@ -188,4 +221,12 @@ Rcpp::LogicalVector fd_cancel(Rcpp::RObject xptr) {
   (*flag)->store(true);
   return true;
 
+}
+
+// Schedules a C function that takes a pointer to an integer vector and a void *
+// argument, to execute on file descriptor readiness. Returns an external
+// pointer that can be used to signal cancellation.
+extern "C" SEXP execLaterFDNative(void (*func)(int *, void *), void *arg, int num_fds, struct pollfd *fds, double timeoutSecs, int loop_id) {
+  ensureInitialized();
+  return execLater_fd_impl(func, arg, num_fds, fds, timeoutSecs, loop_id);
 }

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -1,3 +1,4 @@
+#include "fd.h"
 #include <Rcpp.h>
 #include <unistd.h>
 #include <cstdlib>
@@ -6,15 +7,14 @@
 #include "tinycthread.h"
 #include "later.h"
 #include "callback_registry_table.h"
-#include "fd.h"
 
 extern CallbackRegistryTable callbackRegistryTable;
 
 class ThreadArgs {
 public:
   ThreadArgs(
-    struct pollfd *fds,
     int num_fds = 0,
+    struct pollfd *fds = nullptr,
     double timeout = 0,
     int loop = 0
   )
@@ -132,7 +132,7 @@ Rcpp::RObject execLater_fd_threaded(std::shared_ptr<ThreadArgs> args) {
 
 Rcpp::RObject execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
 
-  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(fds, num_fds, timeout, loop_id);
+  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(num_fds, fds, timeout, loop_id);
   args->callback = std::unique_ptr<Rcpp::Function>(new Rcpp::Function(callback));
 
   return execLater_fd_threaded(args);
@@ -142,7 +142,7 @@ Rcpp::RObject execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pol
 // native version
 Rcpp::RObject execLater_fd_impl(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
 
-  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(fds, num_fds, timeout, loop_id);
+  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(num_fds, fds, timeout, loop_id);
   args->func = std::bind(func, std::placeholders::_1, data);
 
   return execLater_fd_threaded(args);

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -126,7 +126,7 @@ void execLater_launch_thread(std::shared_ptr<ThreadArgs> args) {
 
 }
 
-Rcpp::RObject execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
+SEXP execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
 
   std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(num_fds, fds, timeout, loop_id);
   args->callback = std::unique_ptr<Rcpp::Function>(new Rcpp::Function(callback));
@@ -134,9 +134,7 @@ Rcpp::RObject execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pol
   execLater_launch_thread(args);
 
   Rcpp::XPtr<std::shared_ptr<std::atomic<bool>>> xptr(new std::shared_ptr<std::atomic<bool>>(args->flag), true);
-  SEXP ret = xptr;
-
-  return ret;
+  return xptr;
 
 }
 

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -207,7 +207,7 @@ Rcpp::LogicalVector fd_cancel(Rcpp::RObject xptr) {
 
 // Schedules a C function that takes a pointer to an integer vector and a void *
 // argument, to execute on file descriptor readiness. Returns void.
-extern "C" void execLaterFDNative(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double timeoutSecs, int loop_id) {
+extern "C" void execLaterFdNative(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double timeoutSecs, int loop_id) {
   ensureInitialized();
   execLater_fd_impl(func, data, num_fds, fds, timeoutSecs, loop_id);
 }

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -13,8 +13,8 @@ extern CallbackRegistryTable callbackRegistryTable;
 class ThreadArgs {
 public:
   ThreadArgs(
+    struct pollfd *fds,
     int num_fds = 0,
-    struct pollfd *fds = nullptr,
     double timeout = 0,
     int loop = 0
   )
@@ -102,10 +102,10 @@ static int wait_thread(void *arg) {
 
   if (ready > 0) {
     for (int i = 0; i < args->num_fds; i++) {
-      (*args->results)[i] = (*args->fds)[i].revents == 0 ? 0 : (*args->fds)[i].revents & (POLLIN | POLLOUT) ? 1: R_NaInt;
+      (*args->results)[i] = (*args->fds)[i].revents == 0 ? 0 : (*args->fds)[i].revents & (POLLIN | POLLOUT) ? 1: NA_INTEGER;
     }
   } else if (ready < 0) {
-    std::fill(args->results->begin(), args->results->end(), R_NaInt);
+    std::fill(args->results->begin(), args->results->end(), NA_INTEGER);
   }
 
   callbackRegistryTable.scheduleCallback(later_callback, static_cast<void *>(argsptr.release()), 0, args->loop);
@@ -132,7 +132,7 @@ Rcpp::RObject execLater_fd_threaded(std::shared_ptr<ThreadArgs> args) {
 
 Rcpp::RObject execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
 
-  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(num_fds, fds, timeout, loop_id);
+  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(fds, num_fds, timeout, loop_id);
   args->callback = std::unique_ptr<Rcpp::Function>(new Rcpp::Function(callback));
 
   return execLater_fd_threaded(args);
@@ -142,7 +142,7 @@ Rcpp::RObject execLater_fd_impl(Rcpp::Function callback, int num_fds, struct pol
 // native version
 Rcpp::RObject execLater_fd_impl(void (*func)(int *, void *), void *data, int num_fds, struct pollfd *fds, double timeout, int loop_id) {
 
-  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(num_fds, fds, timeout, loop_id);
+  std::shared_ptr<ThreadArgs> args = std::make_shared<ThreadArgs>(fds, num_fds, timeout, loop_id);
   args->func = std::bind(func, std::placeholders::_1, data);
 
   return execLater_fd_threaded(args);

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -79,10 +79,10 @@ static void later_callback(void *arg) {
 // TODO: implement re-usable background thread.
 static int wait_thread(void *arg) {
 
+  tct_thrd_detach(tct_thrd_current());
+
   std::unique_ptr<std::shared_ptr<ThreadArgs>> argsptr(static_cast<std::shared_ptr<ThreadArgs>*>(arg));
   std::shared_ptr<ThreadArgs> args = *argsptr;
-
-  tct_thrd_detach(tct_thrd_current());
 
   // poll() whilst checking for cancellation at intervals
 

--- a/src/fd.h
+++ b/src/fd.h
@@ -1,0 +1,20 @@
+#ifndef _LATER_FD_H_
+#define _LATER_FD_H_
+
+#ifdef _WIN32
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600 // so R <= 4.1 can find WSAPoll() on Windows
+#endif
+#include <winsock2.h>
+#else
+#include <poll.h>
+#endif
+
+#define LATER_POLL_INTERVAL 1024
+#ifdef _WIN32
+#define LATER_POLL_FUNC WSAPoll
+#else
+#define LATER_POLL_FUNC poll
+#endif
+
+#endif // _LATER_FD_H_

--- a/src/init.c
+++ b/src/init.c
@@ -57,7 +57,7 @@ static const R_CallMethodDef CallEntries[] = {
 
 uint64_t execLaterNative(void (*func)(void*), void* data, double secs);
 uint64_t execLaterNative2(void (*func)(void*), void* data, double secs, int loop);
-SEXP execLaterFDNative(void (*)(int *, void *), void *, int, struct pollfd *, double, int);
+void execLaterFDNative(void (*)(int *, void *), void *, int, struct pollfd *, double, int);
 int apiVersion(void);
 
 void R_init_later(DllInfo *dll) {

--- a/src/init.c
+++ b/src/init.c
@@ -57,7 +57,7 @@ static const R_CallMethodDef CallEntries[] = {
 
 uint64_t execLaterNative(void (*func)(void*), void* data, double secs);
 uint64_t execLaterNative2(void (*func)(void*), void* data, double secs, int loop);
-void execLaterFDNative(void (*)(int *, void *), void *, int, struct pollfd *, double, int);
+void execLaterFdNative(void (*)(int *, void *), void *, int, struct pollfd *, double, int);
 int apiVersion(void);
 
 void R_init_later(DllInfo *dll) {
@@ -84,6 +84,6 @@ void R_init_later(DllInfo *dll) {
   // https://github.com/r-lib/later/issues/97
   R_RegisterCCallable("later", "execLaterNative",  (DL_FUNC)&execLaterNative);
   R_RegisterCCallable("later", "execLaterNative2", (DL_FUNC)&execLaterNative2);
-  R_RegisterCCallable("later", "execLaterFDNative",(DL_FUNC)&execLaterFDNative);
+  R_RegisterCCallable("later", "execLaterFdNative",(DL_FUNC)&execLaterFdNative);
   R_RegisterCCallable("later", "apiVersion",       (DL_FUNC)&apiVersion);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -57,7 +57,7 @@ static const R_CallMethodDef CallEntries[] = {
 
 uint64_t execLaterNative(void (*func)(void*), void* data, double secs);
 uint64_t execLaterNative2(void (*func)(void*), void* data, double secs, int loop);
-SEXP execLaterFDNative(void (*)(int *, void *), void *, int, struct pollfd, double, int);
+SEXP execLaterFDNative(void (*)(int *, void *), void *, int, struct pollfd *, double, int);
 int apiVersion(void);
 
 void R_init_later(DllInfo *dll) {

--- a/src/init.c
+++ b/src/init.c
@@ -4,6 +4,15 @@
 #include <R_ext/Rdynload.h>
 #include <stdint.h> // for uint64_t
 
+#ifdef _WIN32
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600 // so R <= 4.1 can find WSAPoll() on Windows
+#endif
+#include <winsock2.h>
+#else
+#include <poll.h>
+#endif
+
 /* FIXME:
 Check these declarations against the C/Fortran source code.
 */
@@ -56,6 +65,7 @@ static const R_CallMethodDef CallEntries[] = {
 
 uint64_t execLaterNative(void (*func)(void*), void* data, double secs);
 uint64_t execLaterNative2(void (*func)(void*), void* data, double secs, int loop);
+SEXP execLaterFDNative(void (*)(int *, void *), void *, int, struct pollfd, double, int);
 int apiVersion(void);
 
 void R_init_later(DllInfo *dll) {
@@ -82,5 +92,6 @@ void R_init_later(DllInfo *dll) {
   // https://github.com/r-lib/later/issues/97
   R_RegisterCCallable("later", "execLaterNative",  (DL_FUNC)&execLaterNative);
   R_RegisterCCallable("later", "execLaterNative2", (DL_FUNC)&execLaterNative2);
+  R_RegisterCCallable("later", "execLaterFDNative",(DL_FUNC)&execLaterFDNative);
   R_RegisterCCallable("later", "apiVersion",       (DL_FUNC)&apiVersion);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -3,15 +3,7 @@
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 #include <stdint.h> // for uint64_t
-
-#ifdef _WIN32
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600 // so R <= 4.1 can find WSAPoll() on Windows
-#endif
-#include <winsock2.h>
-#else
-#include <poll.h>
-#endif
+#include "fd.h" // for struct pollfd
 
 /* FIXME:
 Check these declarations against the C/Fortran source code.

--- a/src/later.cpp
+++ b/src/later.cpp
@@ -16,7 +16,8 @@ using std::shared_ptr;
 
 static size_t exec_callbacks_reentrancy_count = 0;
 
-static CallbackRegistryTable callbackRegistryTable;
+// callbackRegistryTable has global scope as used in fd.cpp
+CallbackRegistryTable callbackRegistryTable;
 
 
 class ProtectCallbacks {


### PR DESCRIPTION
Hi @jcheng5,

I'm creating this PR here targeting my 'fd' branch (the already open PR) so you can easily see the changes I've made since you last reviewed.

1. Refactored to create an `execLater_fd_impl()`, with `execLater_fd()` becoming just an interface wrapper.
2. Changed the `ThreadArgs` from a struct to a class and have default initializers tied to the class.

The C level function takes a `void(*func)(int*, void*)` signature function, with our results vector as the first argument and the second being arbitrary additional args, and also `pollfd` structs. I think this makes sense at the C level as there are functions e.g. `curl_multi_waitfds()` that return `pollfds` directly rather than just integers.

I'm about 90% done, but opening so you can see where I'm going with this.

Hopefully you'll agree that the refactor makes the code quite a bit cleaner.

Thanks.