### PR TITLE
Persistent Thread for FD Waits

### DIFF
--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -203,6 +203,7 @@ static int wait_thread_persistent(void *arg) {
     } else {
       callbackRegistryTable.scheduleCallback(later_callback, static_cast<void *>(thread_args.release()), 0, args->loop);
     }
+    args = nullptr;
 
     if (cv.lock()) THREAD_RETURN(1);
     cv.busy(false);

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -194,7 +194,7 @@ static int wait_thread_persistent(void *arg) {
 
   while (1) {
 
-    if (!thread_active->load()) break; // set by later_exiting() on unload
+    if (!thread_active->load()) break; // set by cv destructor on exit
 
     std::shared_ptr<ThreadArgs> args = *thread_args;
 
@@ -213,7 +213,7 @@ static int wait_thread_persistent(void *arg) {
 
   }
 
-  cv.destroy(); // must do this from here rather than the destructor to avoid deadlock
+  cv.destroy(); // must do this from here rather than cv destructor to avoid deadlock
   return 0;
 
 }

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -198,7 +198,7 @@ static int wait_thread_persistent(void *arg) {
 
   while (1) {
 
-    if (!thread_active->load()) return(1); // set by later_exiting() on unload
+    if (!thread_active->load()) break; // set by later_exiting() on unload
 
     std::shared_ptr<ThreadArgs> args = *thread_args;
 

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -198,7 +198,7 @@ static int wait_thread_persistent(void *arg) {
 
   while (1) {
 
-    if (!thread_active->load()) THREAD_RETURN(1); // set by later_exiting() on unload
+    if (!thread_active->load()) return(1); // set by later_exiting() on unload
 
     std::shared_ptr<ThreadArgs> args = *thread_args;
 
@@ -240,6 +240,7 @@ static int execLater_launch_thread(std::shared_ptr<ThreadArgs> args) {
 
     if (cv.lock()) return 1;
     if (cv.busy()) { cv.unlock(); break; } // busy so create new single thread
+
     cv.busy(true);
     thread_args = std::move(argsptr);
     if (cv.signal()) { cv.unlock(); return 1; }

--- a/src/fd.cpp
+++ b/src/fd.cpp
@@ -101,7 +101,7 @@ public:
   bool wait() {
     return tct_cnd_wait(&_c, &_m) != tct_thrd_success;
   }
-  bool busy() {
+  bool busy() const {
     return _busy;
   }
   void busy(bool value) {
@@ -229,7 +229,7 @@ static int execLater_launch_thread(std::shared_ptr<ThreadArgs> args) {
       return 1;
 
     if (cv.lock()) return 1;
-    while (!thread_active->load()) { // not the condition, but thread will update this
+    while (!thread_active->load()) { // thread can update this without acquiring lock
       if (cv.wait()) { cv.unlock(); return 1; } // wait for signal from thread
     }
     if (cv.unlock()) return 1;

--- a/src/init.c
+++ b/src/init.c
@@ -87,9 +87,3 @@ void R_init_later(DllInfo *dll) {
   R_RegisterCCallable("later", "execLaterFdNative",(DL_FUNC)&execLaterFdNative);
   R_RegisterCCallable("later", "apiVersion",       (DL_FUNC)&apiVersion);
 }
-
-void later_exiting(void);
-
-void R_unload_later(DllInfo *info) {
-  later_exiting(); // signals wait thread to exit if active
-}

--- a/tests/testthat/test-later-fd.R
+++ b/tests/testthat/test-later-fd.R
@@ -3,8 +3,9 @@ context("test-later-fd.R")
 test_that("later_fd", {
   skip_if_not_installed("nanonext")
 
-  result <- NULL
+  result2 <- result <- NULL
   callback <- function(x) result <<- x
+  callback2 <- function(x) result2 <<- x
   s1 <- nanonext::socket(listen = "inproc://nanonext")
   s2 <- nanonext::socket(dial = "inproc://nanonext")
   fd1 <- nanonext::opt(s1, "recv-fd")
@@ -15,8 +16,15 @@ test_that("later_fd", {
   Sys.sleep(0.2)
   run_now()
   expect_equal(result, c(FALSE, FALSE))
-  later_fd(callback, c(fd1, fd2), exceptfds = c(fd1, fd2), timeout = 0)
+
+  # concurrent waits
+  later_fd(callback, c(fd1, fd2), exceptfds = c(fd1, fd2), timeout = 0.4)
+  later_fd(callback2, c(fd1, fd2), exceptfds = c(fd1, fd2), timeout = 0)
   Sys.sleep(0.2)
+  run_now()
+  expect_equal(result2, c(FALSE, FALSE, FALSE, FALSE))
+  expect_equal(result, c(FALSE, FALSE))
+  Sys.sleep(0.4)
   run_now()
   expect_equal(result, c(FALSE, FALSE, FALSE, FALSE))
 


### PR DESCRIPTION
Hi @jcheng5, this PR again targets my 'fd' branch - the already open PR.

This adds the single persistent thread for doing the waits - as we previously noted.

Avoids the overhead of launching a new thread for each wait and the system resource allocation that goes with that, allowing for potentially much higher throughput.

There are quite some intricacies involved and I have added additional comments in the code itself where I've thought it would be helpful.

Some high level points:
- Persistent thread only launched the first time it is needed.
- If it's busy waiting, additional `later_fd()` requests will fall back to using the current single-wait threads - and I've added tests for this.
- The persistent thread basically waits on a condition variable until signalled from the main thread and then proceeds to `poll()` on the FDs provided, in a loop.
- There's a little intricacy of synchronizing when the thread is first created, otherwise there is potential for deadlock as both threads try to acquire the lock with who gets there first being indeterminate. I let the main thread wait on an atomic flag until signalled to get around this.
- Uses a special purpose condition variable class to keep the code tidy (I've not used the one already in the package as I can't have it throw errors - crucially I need the thread to set the global `thread_active` state before exiting - but it uses the same underlying tinycthreads implementation).
- ~~The package unload hook C function needs to signal the thread to exit and we create a special accessor for it to interact with our C++ classes / pointers.~~ solved by https://github.com/shikokuchuo/later/pull/2#issuecomment-2448580612

Ultimately I'm quite comfortable with how this works as I implement these synchronization primitives in nanonext/mirai and similar things happen there.